### PR TITLE
Disallow a password pushed to be removed by the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Default value: `5`
 
 Number of visualizations until the password is deleted.
 
+### --disallow-delete | -r
+Disallow the viewer to delete the password before expiration (by default viewers are allowed to delete the password)
+
 ## Options
 
 ###  --allow-weak

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -98,14 +98,13 @@ test(`Should allow weak password if --allow-weak flag is set`, () => {
 test(`Should disallow viewers to delete password if --disallow-delete flag is set`, (done) => {
   mockRequest(responseValid)
 
-  pwpush({ 'disallow-delete': true, password: objDefault.password })
+  pwpush({ disallow_delete: true, password: objDefault.password })
     .then((res) => {
       result = querystring.parse(res._.config.data)
       expected = {
         'password[payload]': objDefault.password,
         'password[expire_after_days]': objDefault.expire_days,
         'password[expire_after_views]': objDefault.expire_views,
-        'password[deletable_by_viewer]': 'on',
       }
 
       expect(result).toEqual(expected)

--- a/cli.js
+++ b/cli.js
@@ -10,9 +10,10 @@ const showHelp = (txt = '\r') => {
     \r  $ pwpush <password> [parameters] [options]
 
     \rParameters
-    \r  --days  | -d  Days until the password is deleted. Default is ${pwpush.DEFAULT_EXPIRE_DAYS}
-    \r  --views | -v  Number of visualizations until the password is deleted. Default is ${pwpush.DEFAULT_EXPIRE_VIEWS}
-    \r  --list  | -l  List last ${pwpush.DEFAULT_LAST_ITEMS} pushed passwords.
+    \r  --days            | -d  Days until the password is deleted. Default is ${pwpush.DEFAULT_EXPIRE_DAYS}
+    \r  --views           | -v  Number of visualizations until the password is deleted. Default is ${pwpush.DEFAULT_EXPIRE_VIEWS}
+    \r  --list            | -l  List last ${pwpush.DEFAULT_LAST_ITEMS} pushed passwords.
+    \r  --disallow-delete | -r  Disallow viewers to delete password before expiration Default is ${pwpush.DEFAULT_ALLOW_DELETE}
 
     \rOptions
     \r  --allow-weak  Allow weak passwords to be used.
@@ -27,10 +28,11 @@ const showHelp = (txt = '\r') => {
 }
 
 const cli = parseArgs(process.argv.slice(2), {
-  boolean: ['version', 'help', 'allow-weak', 'list'],
+  boolean: ['version', 'help', 'allow-weak', 'allow-delete', 'list'],
   alias: {
     d: 'days',
     v: 'views',
+    r: 'disallow-delete',
     l: 'list',
     h: 'help',
   },
@@ -60,6 +62,7 @@ try {
     password: cli._[0],
     expire_days: cli.days,
     expire_views: cli.views,
+    allow_delete: cli['disallow-delete'],
     allow_weak: cli['allow-weak'],
   })
   .then(res => {

--- a/cli.js
+++ b/cli.js
@@ -62,7 +62,7 @@ try {
     password: cli._[0],
     expire_days: cli.days,
     expire_views: cli.views,
-    allow_delete: cli['disallow-delete'],
+    disallow_delete: cli['disallow-delete'],
     allow_weak: cli['allow-weak'],
   })
   .then(res => {

--- a/lib/pwpush.js
+++ b/lib/pwpush.js
@@ -7,6 +7,7 @@ const querystring = require('querystring')
 const DEFAULT_EXPIRE_DAYS = '7'
 const DEFAULT_EXPIRE_VIEWS = '5'
 const DEFAULT_LAST_ITEMS = '5'
+const DEFAULT_DISALLOW_DELETE = false;
 const HOST = 'https://pwpush.com'
 const PERMALINK = `${HOST}/p`
 
@@ -77,6 +78,7 @@ module.exports = ({
   password,
   expire_days = DEFAULT_EXPIRE_DAYS,
   expire_views = DEFAULT_EXPIRE_VIEWS,
+  disallow_delete = DEFAULT_DISALLOW_DELETE,
   allow_weak = false,
   showHistory
 }) => {
@@ -92,15 +94,20 @@ module.exports = ({
       \r=> https://bit.ly/owasp-secure-guideline`)
   }
 
+  const requestData = {
+    'password[payload]': password,
+    'password[expire_after_days]': expire_days,
+    'password[expire_after_views]': expire_views,
+  };
+
+  if (!disallow_delete) {
+    requestData['password[deletable_by_viewer]'] = 'on';
+  }
+
   const reqOptions = {
     method: 'post',
     url: `${HOST}/p.json`,
-    data: querystring.stringify({
-      'password[payload]': password,
-      'password[expire_after_days]': expire_days,
-      'password[expire_after_views]': expire_views,
-      'password[deletable_by_viewer]': 'on',
-    }),
+    data: querystring.stringify(requestData),
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Accept': 'text/html,application/xhtml+xml,application/xml',

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,10 +80,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ansi-escapes": {
@@ -416,7 +416,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -922,7 +922,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "boom": {
@@ -931,7 +931,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -1197,7 +1197,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -1276,11 +1276,11 @@
       "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
       "dev": true,
       "requires": {
-        "js-yaml": "3.11.0",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.85.0"
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
       }
     },
     "cross-spawn": {
@@ -1300,7 +1300,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -1309,7 +1309,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -1335,7 +1335,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -1519,7 +1519,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "end-of-stream": {
@@ -1852,9 +1852,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -2462,7 +2462,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2548,8 +2548,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -2647,10 +2647,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
@@ -2690,9 +2690,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "husky": {
@@ -3645,8 +3645,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4076,7 +4076,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -4243,7 +4243,7 @@
       "integrity": "sha1-YPSjb8lYoDDx+6g+4VEKrS6o4S4=",
       "requires": {
         "shell-escape": "0.0.0",
-        "switchy": "0.1.0"
+        "switchy": "^0.1.0"
       }
     },
     "node-int64": {
@@ -4994,28 +4994,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "request-promise-core": {
@@ -5649,7 +5649,7 @@
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -5739,14 +5739,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-utils": {
@@ -5947,7 +5947,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -5979,7 +5979,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -6166,9 +6166,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "w3c-hr-time": {


### PR DESCRIPTION
Currently it is not possible to disallow a viewer to delete a password pushed since the param `password[deletable_by_viewer]` is always set to `on`

This is a pull request keep this option as default, but provide an opportunity to disallow password deletion